### PR TITLE
Made ALT Texts a bit longer

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,40 +24,40 @@
             <p id="tie-game">Aww! It's a tie!</p>
         </section>
         <div class="cell left top" data-loc="0">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell middle top" data-loc="1">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell right top" data-loc="2">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell middle left" data-loc="3">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell middle center" data-loc="4">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell middle right" data-loc="5">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell bottom left" data-loc="6">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell bottom middle" data-loc="7">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
         <div class="cell bottom right" data-loc="8">
-            <img src="tic-O.svg" alt="O">
-            <img src="tac-X.svg" alt="X">
+            <img src="tic-O.svg" alt="O mark">
+            <img src="tac-X.svg" alt="X mark">
         </div>
     </fieldset>
     <script src="script.js"></script>


### PR DESCRIPTION
Basicly what I made is that I fixed Google chrome trying to fetch its own descriptions with the X and O ALT ALready provided descriptions, providing 2 distinct descriptions to Screen Reader Users, or if descriptions are turned off, telling them that the image is unlabeled when it is.
So what I made is that I made the ALTS longer by saying "O mark" instead of "O" for example, which should stop that.
